### PR TITLE
Declare a package for the implementation and its tests

### DIFF
--- a/alloc1.lisp
+++ b/alloc1.lisp
@@ -36,6 +36,8 @@
 ;; itself contains the resulting information and the
 ;; symbol table is discarded.
 
+(in-package :wam)
+
 (defun allocate (tree)
   (let ((symbols (nreverse (alloc-top-level tree 0 nil)))
         (has-locals nil))

--- a/asm.lisp
+++ b/asm.lisp
@@ -21,6 +21,8 @@
 ;;
 ;; uses objects of type io for input and output
 
+(in-package :wam)
+
 (defvar *pc* 0)
 (defvar *labels* nil)
 (defvar *pc-start* 0)

--- a/coder.lisp
+++ b/coder.lisp
@@ -12,6 +12,7 @@
 ;; The top level of the coder is the defrel function which
 ;; defines groups of relations - all with the same name, but
 ;; possibly with different arities
+(in-package :wam)
 
 (defvar *ctable* (make-hash-table))
 (defvar *next-label* 0)

--- a/compare/README.md
+++ b/compare/README.md
@@ -1,6 +1,8 @@
 This directory contains various tests of the WAM.
 
-Currently, the tests are compiled by gplc to WAM code, then manually compared to the emitted (Lisp) WAM code.
+Currently, the tests are compiled by gplc to WAM code, then manually
+compared to the emitted (Lisp) WAM code.
 
 to compile to wam
-gplc -W file.pl
+
+    gplc -W file.pl

--- a/const.lisp
+++ b/const.lisp
@@ -1,3 +1,4 @@
+(in-package :wam)
 
 (defconstant put-x-variable 1)
 (defconstant put-y-variable 2)

--- a/defsys.lisp
+++ b/defsys.lisp
@@ -1,3 +1,4 @@
+;; Duplicated in <file:wam.asd> to allow encapsulation in ASDF
 (defsystem wam (:optimize ((speed 0) (space 0) (safety 3) (debug 3)))
   :members ("const"
             "wam"

--- a/io.lisp
+++ b/io.lisp
@@ -1,5 +1,7 @@
 ; $Id: io.lisp,v 1.1 2006/02/04 06:34:22 tarvydas Exp $
-; Copyright 2005 Paul Tarvydas
+                                        ; Copyright 2005 Paul Tarvydas
+
+(in-package :wam)
 
 (defclass io () ())
 (defgeneric next-element (x))

--- a/opcodes.lisp
+++ b/opcodes.lisp
@@ -1,6 +1,8 @@
 ; $Id: opcodes.lisp,v 1.4 2006/02/18 22:49:02 tarvydas Exp $
 ;; Copyright 2005 Paul Tarvydas
 
+(in-package :wam)
+
 (defparameter *opcodes* (make-hash-table :test 'equal))
 
 (defun init-opcodes ()

--- a/package.lisp
+++ b/package.lisp
@@ -1,0 +1,9 @@
+(defpackage wam
+  (:use :cl)
+  (:export
+   #:code))
+
+(defpackage wam/test
+  (:use :cl
+        :wam))
+

--- a/parse.lisp
+++ b/parse.lisp
@@ -1,5 +1,6 @@
-; $Id: parse.lisp,v 1.7 2006/02/18 22:49:02 tarvydas Exp $
-; Copyright 2006 Paul Tarvydas
+                                        ; $Id: parse.lisp,v 1.7 2006/02/18 22:49:02 tarvydas Exp $
+                                        ; Copyright 2006 Paul Tarvydas
+(in-package :Wam)
 
 (defun parse-rule (list)
   (let* ((head (car list))

--- a/readme
+++ b/readme
@@ -1,0 +1,11 @@
+# WAM Prolog
+
+Paul Tarvydes
+
+## Locating the source 
+
+Place into places that implementations look for ASDF systems.  For
+example, if you have Quicklisp installed, it always looks in
+<file:~/quicklisp/local-projects/>
+
+c.f. <http://blog.quicklisp.org/2018/01/the-quicklisp-local-projects-mechanism.html>

--- a/test/parse-test.lisp
+++ b/test/parse-test.lisp
@@ -1,3 +1,4 @@
+(in-package :wam/test)
 
 (defun test0 ()
   (pprint (parse-rule '((father paul albin)))))

--- a/test/test.lisp
+++ b/test/test.lisp
@@ -1,4 +1,5 @@
-; Copyright 2005 Paul Tarvydas
+;;; Copyright 2005 Paul Tarvydas
+(in-package :wam/test)
 
 (defun labelp (x)
   (char= #\$ (char (symbol-name x) 0)))

--- a/wam.asd
+++ b/wam.asd
@@ -1,0 +1,35 @@
+(defsystem wam
+  :components ((:file "package")))
+
+(defsystem wam/all
+  :depends-on (wam)
+  :components ((:module source :pathname "./" :components
+                        ((:file "wutil") ;; FIXME:  DUMP-TAG doesn't work on type selector
+                         (:file "coder")
+                         (:file "asm")
+                         (:file "const")
+                         (:file "parse")
+                         (:file "io")
+                         (:file "opcodes")
+                         (:file "alloc1")
+                         (:file "wam")))))
+
+(defsystem wam/test
+  :depends-on (wam)
+  :components ((:module suite :pathname "test/" :components
+                        ((:file "parse-test")
+                         (:file "test")))))
+
+(defsystem wam/compare
+  :depends-on (wam)
+  :components ((:module suite :pathname "compare/" :components
+                        ((:static-file "grandfather.pl")  ;; TODO add proper class for Prolog source files
+                         (:static-file "t13.pl")
+                         (:static-file "t14.pl")
+                         (:static-file "t15.pl")))))
+
+
+                        
+
+
+               

--- a/wam.lisp
+++ b/wam.lisp
@@ -41,6 +41,8 @@
 
 ;; section 2.2 discusses compilation of *queries*, section 2.3 discusses compilation of *programs*+ 
 
+(in-package :wam)
+
 (proclaim '(optimize (debug 3) (safety 3) (speed 0) (space 0)))
 
 (declaim (optimize (debug 3) (safety 3) (speed 0) (space 0)))

--- a/wutil.lisp
+++ b/wutil.lisp
@@ -1,5 +1,6 @@
 ; $Id$
-; Copyright 2005 Paul Tarvydas
+                                        ; Copyright 2005 Paul Tarvydas
+(in-package :wam)
 
 (defun dump ()
   (format t "p=~A cp=~A s=~A h=~A hb=~A b=~A b0=~A e=~A tr=~A mode=~A~%"
@@ -29,6 +30,7 @@
 (defun unconst (x)
   (gethash x unconsts))
 
+#+(or) ;; FIXME ccl-1.12-dev-macos can't grok this
 (defun dump-tag (x)
   (case (tag x)
     (#.int "int")


### PR DESCRIPTION
Compiles under ccl-1.12-dev-macos and sbcl-1.4.16.

Able to load via ASDF:LOAD-OP once this source can be scanned by ASDF.